### PR TITLE
[setting/#5] 리퀴드 글라서 효과 설정 끄기

### DIFF
--- a/KORAILTALK-iOS/KORAILTALK-iOS.xcodeproj/project.pbxproj
+++ b/KORAILTALK-iOS/KORAILTALK-iOS.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 				DEVELOPMENT_TEAM = 6B47X24XTW;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "KORAILTALK-iOS/Info.plist";
+				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
@@ -180,6 +181,7 @@
 				DEVELOPMENT_TEAM = 6B47X24XTW;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "KORAILTALK-iOS/Info.plist";
+				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;

--- a/KORAILTALK-iOS/KORAILTALK-iOS/Info.plist
+++ b/KORAILTALK-iOS/KORAILTALK-iOS/Info.plist
@@ -21,5 +21,7 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## 🚄 작업 내용
- 리퀴드 글라스 효과 OFF

## 💺 주요 코드 설명
<!-- 코드 설명, 없다면 생략해도 됩니다! -->
### 리퀴드 글라스 효과 OFF
```Swift
<key>UIDesignRequiresCompatibility</key>
	<true/>
```
`info.plist` 파일에 `UIDesignRequiesCompatibility` 설정을 `true` 로 변경하면 리퀴드 글라스 효과가 꺼진다.


## 🚂 연결된 이슈
- Connected: #5 


## 🚉 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
[UIDesignRequiresCompatibility](https://developer.apple.com/documentation/BundleResources/Information-Property-List/UIDesignRequiresCompatibility
)
## 🚃 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
후.... 조심 조심.... 항상 브랜치 확인하기
