### PR TITLE
[feat/#16] checkbox 컴포넌트 추가

### DIFF
--- a/KORAILTALK-iOS/KORAILTALK-iOS.xcodeproj/project.pbxproj
+++ b/KORAILTALK-iOS/KORAILTALK-iOS.xcodeproj/project.pbxproj
@@ -164,7 +164,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UIMainStoryboardFile = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -197,7 +197,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UIMainStoryboardFile = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/KORAILTALK-iOS/KORAILTALK-iOS/Global/Components/CheckBox.swift
+++ b/KORAILTALK-iOS/KORAILTALK-iOS/Global/Components/CheckBox.swift
@@ -1,0 +1,50 @@
+//
+//  CheckBox.swift
+//  KORAILTALK-iOS
+//
+//  Created by sumin Kong on 11/19/25.
+//
+import UIKit
+
+final class CheckBox: UIButton {
+    var checkedImage = UIImage(named: "checkbox_on")
+    var uncheckedImage = UIImage(named: "checkbox_off")
+    
+    var isCheckd: Bool = false {
+        didSet {
+            updateImage()
+        }
+    }
+    
+    private let fixedSize = CGSize(width: 24, height: 24)
+    
+    override init(frame: CGRect){
+        let fixedFrame = CGRect(origin: frame.origin, size: fixedSize)
+        super.init(frame: fixedFrame)
+        setupButton()
+    }
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        self.frame.size = fixedSize
+        setupButton()
+    }
+    
+    private func setupButton() {
+        updateImage()
+        self.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+    }
+    
+    @objc
+    func buttonTapped() {
+        self.isCheckd.toggle()
+    }
+    
+    private func updateImage() {
+        if isCheckd {
+            self.setImage(checkedImage, for: .normal)
+        }else {
+            self.setImage(uncheckedImage, for: .normal)
+        }
+    }
+    
+}

--- a/KORAILTALK-iOS/KORAILTALK-iOS/Global/Resources/Assets.xcassets/checkbox_off.imageset/Contents.json
+++ b/KORAILTALK-iOS/KORAILTALK-iOS/Global/Resources/Assets.xcassets/checkbox_off.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "checkbox_off.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/KORAILTALK-iOS/KORAILTALK-iOS/Global/Resources/Assets.xcassets/checkbox_off.imageset/checkbox_off.svg
+++ b/KORAILTALK-iOS/KORAILTALK-iOS/Global/Resources/Assets.xcassets/checkbox_off.imageset/checkbox_off.svg
@@ -1,0 +1,3 @@
+<svg width="44" height="44" viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="11" y="11" width="22" height="22" rx="3" stroke="#4A91C7" stroke-width="2"/>
+</svg>

--- a/KORAILTALK-iOS/KORAILTALK-iOS/Global/Resources/Assets.xcassets/checkbox_on.imageset/Contents.json
+++ b/KORAILTALK-iOS/KORAILTALK-iOS/Global/Resources/Assets.xcassets/checkbox_on.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "checkbox_on.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/KORAILTALK-iOS/KORAILTALK-iOS/Global/Resources/Assets.xcassets/checkbox_on.imageset/checkbox_on.svg
+++ b/KORAILTALK-iOS/KORAILTALK-iOS/Global/Resources/Assets.xcassets/checkbox_on.imageset/checkbox_on.svg
@@ -1,0 +1,4 @@
+<svg width="44" height="44" viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="10" y="10" width="24" height="24" rx="4" fill="#4A91C7"/>
+<path d="M28 18L19.75 26L16 22.3636" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/KORAILTALK-iOS/KORAILTALK-iOS/Info.plist
+++ b/KORAILTALK-iOS/KORAILTALK-iOS/Info.plist
@@ -21,8 +21,6 @@
 					<string>Default Configuration</string>
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
-					<key>UISceneStoryboardFile</key>
-					<string>Main</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
## 🚄 작업 내용
- checkbox 컴포넌트

## 💺 주요 코드 설명
### checkbox
```Swift
private let fixedSize = CGSize(width: 24, height: 24)
let checkBoxEx = CheckBox(frame: CGRect(x: 50, y: 100, width: 0, height: 0))
```
- 크기는 피그마와 같이 24x24로 고정해두었습니다.
- 사용하실 때는 checkBoxEx 방식으로 쓰시면 됩니다

## 🛤️ 구현화면


|   checkbox 컴포넌트   |
| :----------: |
| <img src = "https://github.com/user-attachments/assets/cf308448-45c7-4d0a-9d91-87385d5885fe" width ="250"> |


## 🚂 연결된 이슈
- Connected: #16 

## 🚃 기타 더 이야기해볼 점
- 스토리보드 삭제했더욤

